### PR TITLE
Traitors get an implanted Syndicate Radio at round start.

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -225,6 +225,8 @@
 			show_tips("traitor")
 			if(should_equip)
 				equip(silent)
+			var/obj/item/implant/radio/syndicate/I = new /obj/item/implant/radio/syndicate()
+			I.implant(owner.current, null, TRUE, TRUE)
 			owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/tatoralert.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 
 /datum/antagonist/traitor/apply_innate_effects(mob/living/mob_override)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1815,7 +1815,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/implants/radio
 	name = "Internal Syndicate Radio Implant"
 	desc = "An implant injected into the body, allowing the use of an internal Syndicate radio. \
-			Used just like a regular headset, but can be disabled to use external headsets normally and to avoid detection."
+			Used just like a regular headset, but can be disabled to use external headsets normally and to avoid detection. \
+			You should already have one implanted in you, though."
 	item = /obj/item/storage/box/syndie_kit/imp_radio
 	cost = 4
 	exclude_modes = list(/datum/game_mode/incursion) //To prevent traitors from immediately outing the hunters to security.

--- a/html/antagtips/traitor.html
+++ b/html/antagtips/traitor.html
@@ -2,6 +2,7 @@
 	<center>
 	<h1>You are a Traitor!</h1>
 	<img src="traitor.png"/>
+	<p>Update: USE YOUR IMPLANTED RADIO BY PREFIXING YOUR MESSAGE WITH :t, THANK YOU.</p>
 	<p>The syndicate has provided you with a disguised uplink. It can either be your PDA, your headset, your pen or an attachable hand accessory that's currently stored in your bag.</p>
 	<p>The details of your objective are stored within your notes, to see them use the Notes verb.</p>
 	<p><img src="pda.png"/>To utilize your <b>PDA</b> uplink, enter the messenger tab and set the ringtone as the code you have been provided.</p>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## About The Pull Request
Traitors now get an implanted Syndicate radio headset roundstart.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Traitors cooperating is a good thing, it allows traitors to keep talking even after radio confiscation, and lavaland Syndies finally get a good use!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Traitors now get a Syndicate Radio Implant for free, talk over it with :t.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
