### PR TITLE
AI Objective Panels-An informational Catastrophe.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -44,8 +44,15 @@
 	radiomod = ";" //AIs will, by default, state their laws on the internal radio.
 	var/obj/item/multitool/aiMulti
 	var/mob/living/simple_animal/bot/Bot
+	var/mob/living/silicon/robot/Cyborg
 	var/tracking = FALSE //this is 1 if the AI is currently tracking somebody, but the track has not yet been completed.
 	var/datum/effect_system/spark_spread/spark_system //So they can initialize sparks whenever/N
+	//Cyborg Pathing Variables
+	var/list/path = list() //Pathing for Cyborg Waypoints
+
+	//Cyborg Objective Updates
+	var/objectiveupdate //A.I inputting new objective.
+	var/objectivesconfirm //High, Low, Medium Priority?
 
 	//MALFUNCTION
 	var/datum/module_picker/malf_picker
@@ -157,7 +164,7 @@
 		add_verb(list(/mob/living/silicon/ai/proc/ai_network_change, \
 		/mob/living/silicon/ai/proc/ai_statuschange, /mob/living/silicon/ai/proc/ai_hologram_change, \
 		/mob/living/silicon/ai/proc/botcall, /mob/living/silicon/ai/proc/control_integrated_radio, \
-		/mob/living/silicon/ai/proc/set_automatic_say_channel))
+		/mob/living/silicon/ai/proc/set_automatic_say_channel, /mob/living/silicon/ai/proc/borgmanagement))
 
 	GLOB.ai_list += src
 	GLOB.shuttle_caller_list += src
@@ -473,7 +480,25 @@
 	if(href_list["botrefresh"]) //Refreshes the bot control panel.
 		botcall()
 		return
-
+	if(href_list["cyborgrefresh"]) //Refreshes the cyborg management panel.
+		borgmanagement()
+		return
+	if(href_list["cyborgmessage"])
+		var/cyborgmessage = input(src, "What would you like to say to this unit.", "Contact Cyborg")
+		Cyborg = locate(href_list["cyborgmessage"]) in GLOB.alive_mob_list
+		if(!Cyborg)
+			return
+		to_chat(Cyborg, "<span class='notice'>Message recieved from stationbound A.I:<font color='yellow'> [cyborgmessage] </font></span>")
+	if(href_list["flagwaypoint"])
+		Cyborg = locate(href_list["flagwaypoint"]) in GLOB.alive_mob_list
+		waypoint_mode = 1
+		if(!Cyborg)
+			return
+	if(href_list["objectivemanage"])
+		Cyborg = locate(href_list["objectivemanage"]) in GLOB.alive_mob_list
+		objectivesconfirm = alert(src, "Indicate Priority level before assignment.", "Priority Level", "Low", "Medium", "High")
+		objectiveupdate = input(src, "Describe Objective Update for Synced Synthetic", "Objective Update")
+		Cyborg.objectivesupdate()
 	if (href_list["ai_take_control"]) //Mech domination
 		var/obj/mecha/M = locate(href_list["ai_take_control"]) in GLOB.mechas_list
 		if (!M)
@@ -552,8 +577,10 @@
 		//The target must be in view of a camera or near the core.
 	if(turf_check in range(get_turf(src)))
 		call_bot(turf_check)
+		call_cyborg()
 	else if(GLOB.cameranet && GLOB.cameranet.checkTurfVis(turf_check))
 		call_bot(turf_check)
+		call_cyborg()
 	else
 		to_chat(src, "<span class='danger'>Selected location is not visible.</span>")
 
@@ -609,6 +636,44 @@
 	if (viewalerts)
 		ai_alerts()
 	return 1
+
+/mob/living/silicon/ai/proc/borgmanagement() //Shamelessly Stolen from Botcall()
+	set category = "AI Commands"
+	set name = "Access Cyborg Management"
+	set desc = "Provide Pathing, Remote Communiques, and other data on linked synthetics."
+	if(incapacitated())
+		return
+	if(control_disabled)
+		to_chat(src, "<span class='warning'>Wireless control is disabled.</span>")
+		return
+	var/turf/ai_current_turf = get_turf(src)
+	var/ai_Zlevel = ai_current_turf.get_virtual_z_level()
+	var/c
+	c += "<A HREF=?src=[REF(src)];cyborgrefresh=1>Query network status</A><br>"
+	c += "<table width='100%'><tr><td width='40%'><h3>Name</h3></td><td width='30%'><h3>Status</h3></td><td width='30%'><h3>Location</h3></td><td width='10%'><h3>Control</h3></td></tr>"
+
+	for(var/mob/living/silicon/robot/G in connected_robots)
+		if(G.get_virtual_z_level() == ai_Zlevel && !G.emagged) //Only non-emagged Cyborgs on the same Z-level are detected!
+			c += "<tr><td width='30%'>Designation: [G.name]</A> (Module: [G.designation])</td>"
+			c += "<td width='30%'>Integrity: [G.health]% 	 		Flagged as: [G.busystatus ? "Occupied" : "Unoccupied"]		Current Objective: [objectiveupdate]</td>"
+			c += "<td width='30%'>Location: [get_area_name(G, TRUE)]</td>" //Where is BORGIE????
+			c += "<td width='30%'>Cell: [G.cell ? "[G.cell.charge]/[G.cell.maxcharge]" : "Empty"]</td>"
+			c += "<td width='15%'><A HREF=?src=[REF(src)];cyborgmessage=[REF(G)]>Private Message</A></td>"
+			c += "<td width='15%'><A HREF=?src=[REF(src)];flagwaypoint=[REF(G)]>Flag-Waypoint</A></td>" //Flag a Pain in the Ass is what this is.
+			c += "<td width='15%'><A HREF=?src=[REF(src)];objectivemanage=[REF(G)]>Update Objective</A></td>" 
+			c += "</tr>"
+			c = format_text(c)
+
+	var/datum/browser/popup = new(src, "cyborgmanagement", "Remote Cyborg Management", 700, 400)
+	popup.set_content(c)
+	popup.open()
+
+/mob/living/silicon/ai/proc/call_cyborg(turf/waypoint)
+
+	if(!Cyborg)
+		return
+	Cyborg.flagwaypoint(src, waypoint)
+
 
 /mob/living/silicon/ai/freeCamera(area/home, obj/machinery/camera/cam)
 	for(var/class in alarms)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -489,11 +489,13 @@
 		if(!Cyborg)
 			return
 		to_chat(Cyborg, "<span class='notice'>Message recieved from stationbound A.I:<font color='yellow'> [cyborgmessage] </font></span>")
+/**	
 	if(href_list["flagwaypoint"])
 		Cyborg = locate(href_list["flagwaypoint"]) in GLOB.alive_mob_list
 		waypoint_mode = 1
 		if(!Cyborg)
 			return
+*/
 	if(href_list["objectivemanage"])
 		Cyborg = locate(href_list["objectivemanage"]) in GLOB.alive_mob_list
 		objectivesconfirm = alert(src, "Indicate Priority level before assignment.", "Priority Level", "Low", "Medium", "High")
@@ -577,10 +579,10 @@
 		//The target must be in view of a camera or near the core.
 	if(turf_check in range(get_turf(src)))
 		call_bot(turf_check)
-		call_cyborg()
+//		call_cyborg()
 	else if(GLOB.cameranet && GLOB.cameranet.checkTurfVis(turf_check))
 		call_bot(turf_check)
-		call_cyborg()
+//		call_cyborg()
 	else
 		to_chat(src, "<span class='danger'>Selected location is not visible.</span>")
 
@@ -659,7 +661,7 @@
 			c += "<td width='30%'>Location: [get_area_name(G, TRUE)]</td>" //Where is BORGIE????
 			c += "<td width='30%'>Cell: [G.cell ? "[G.cell.charge]/[G.cell.maxcharge]" : "Empty"]</td>"
 			c += "<td width='15%'><A HREF=?src=[REF(src)];cyborgmessage=[REF(G)]>Private Message</A></td>"
-			c += "<td width='15%'><A HREF=?src=[REF(src)];flagwaypoint=[REF(G)]>Flag-Waypoint</A></td>" //Flag a Pain in the Ass is what this is.
+//			c += "<td width='15%'><A HREF=?src=[REF(src)];flagwaypoint=[REF(G)]>Flag-Waypoint</A></td>" //Flag a Pain in the Ass is what this is.
 			c += "<td width='15%'><A HREF=?src=[REF(src)];objectivemanage=[REF(G)]>Update Objective</A></td>" 
 			c += "</tr>"
 			c = format_text(c)
@@ -668,13 +670,14 @@
 	popup.set_content(c)
 	popup.open()
 
+/**
 /mob/living/silicon/ai/proc/call_cyborg(turf/waypoint)
 
 	if(!Cyborg)
 		return
 	Cyborg.flagwaypoint(src, waypoint)
 
-
+*/
 /mob/living/silicon/ai/freeCamera(area/home, obj/machinery/camera/cam)
 	for(var/class in alarms)
 		var/our_area = alarms[class][home.name]

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -489,13 +489,7 @@
 		if(!Cyborg)
 			return
 		to_chat(Cyborg, "<span class='notice'>Message recieved from stationbound A.I:<font color='yellow'> [cyborgmessage] </font></span>")
-/**	
-	if(href_list["flagwaypoint"])
-		Cyborg = locate(href_list["flagwaypoint"]) in GLOB.alive_mob_list
-		waypoint_mode = 1
-		if(!Cyborg)
-			return
-*/
+
 	if(href_list["objectivemanage"])
 		Cyborg = locate(href_list["objectivemanage"]) in GLOB.alive_mob_list
 		objectivesconfirm = alert(src, "Indicate Priority level before assignment.", "Priority Level", "Low", "Medium", "High")
@@ -579,10 +573,8 @@
 		//The target must be in view of a camera or near the core.
 	if(turf_check in range(get_turf(src)))
 		call_bot(turf_check)
-//		call_cyborg()
 	else if(GLOB.cameranet && GLOB.cameranet.checkTurfVis(turf_check))
 		call_bot(turf_check)
-//		call_cyborg()
 	else
 		to_chat(src, "<span class='danger'>Selected location is not visible.</span>")
 
@@ -661,7 +653,6 @@
 			c += "<td width='30%'>Location: [get_area_name(G, TRUE)]</td>" //Where is BORGIE????
 			c += "<td width='30%'>Cell: [G.cell ? "[G.cell.charge]/[G.cell.maxcharge]" : "Empty"]</td>"
 			c += "<td width='15%'><A HREF=?src=[REF(src)];cyborgmessage=[REF(G)]>Private Message</A></td>"
-//			c += "<td width='15%'><A HREF=?src=[REF(src)];flagwaypoint=[REF(G)]>Flag-Waypoint</A></td>" //Flag a Pain in the Ass is what this is.
 			c += "<td width='15%'><A HREF=?src=[REF(src)];objectivemanage=[REF(G)]>Update Objective</A></td>" 
 			c += "</tr>"
 			c = format_text(c)
@@ -670,14 +661,6 @@
 	popup.set_content(c)
 	popup.open()
 
-/**
-/mob/living/silicon/ai/proc/call_cyborg(turf/waypoint)
-
-	if(!Cyborg)
-		return
-	Cyborg.flagwaypoint(src, waypoint)
-
-*/
 /mob/living/silicon/ai/freeCamera(area/home, obj/machinery/camera/cam)
 	for(var/class in alarms)
 		var/our_area = alarms[class][home.name]

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -649,7 +649,7 @@
 	for(var/mob/living/silicon/robot/G in connected_robots)
 		if(G.get_virtual_z_level() == ai_Zlevel && !G.emagged) //Only non-emagged Cyborgs on the same Z-level are detected!
 			c += "<tr><td width='30%'>Designation: [G.name]</A> (Module: [G.designation])</td>"
-			c += "<td width='30%'>Integrity: [G.health]% 	 		Flagged as: [G.busystatus ? "Occupied" : "Unoccupied"]		Current Objective: [objectiveupdate]</td>"
+			c += "<td width='30%'>Integrity: [G.health]% <BR>Flagged as: [G.busystatus ? "Occupied" : "Unoccupied"]	<BR>Current Objective: [objectiveupdate]</td>"
 			c += "<td width='30%'>Location: [get_area_name(G, TRUE)]</td>" //Where is BORGIE????
 			c += "<td width='30%'>Cell: [G.cell ? "[G.cell.charge]/[G.cell.maxcharge]" : "Empty"]</td>"
 			c += "<td width='15%'><A HREF=?src=[REF(src)];cyborgmessage=[REF(G)]>Private Message</A></td>"

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -51,8 +51,8 @@
 	var/list/path = list() //Pathing for Cyborg Waypoints
 
 	//Cyborg Objective Updates
-	var/objectiveupdate //A.I inputting new objective.
-	var/objectivesconfirm //High, Low, Medium Priority?
+	var/objectiveupdate = "No Assigned Objective" //A.I inputting new objective.
+	var/objectivesconfirm = "Unregistered" //High, Low, Medium Priority?
 
 	//MALFUNCTION
 	var/datum/module_picker/malf_picker

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -52,7 +52,7 @@
 
 	//Cyborg Objective Updates
 	var/objectiveupdate = "No Assigned Objective" //A.I inputting new objective.
-	var/objectivesconfirm = "Unregistered" //High, Low, Medium Priority?
+	var/objectivesconfirm = "Minimum" //High, Low, Medium Priority?
 
 	//MALFUNCTION
 	var/datum/module_picker/malf_picker

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -331,7 +331,7 @@
 	if(connected_ai)
 		tab_data["Master AI"] = GENERATE_STAT_TEXT("[connected_ai.name]")
 		for(var/mob/living/silicon/ai/AI) //I don't understand why this needs to be under For, but it does. 
-			tab_data["A.I Objective"] = GENERATE_STAT_TEXT("[AI.objectiveupdate]") //What are your Orders Master A.I?
+			tab_data["[AI.objectivesconfirm] priority A.I Objective"] = GENERATE_STAT_TEXT("[AI.objectiveupdate]") //What are your Orders Master A.I?
 			tab_data["Busy Flag"] = GENERATE_STAT_TEXT("[busystatus ? "Utilized" : "Standing-by"]")
 	return tab_data
 
@@ -1273,6 +1273,7 @@
 	var/mob/living/silicon/ai/AI
 	to_chat(src, "<span class='notice'>A.I Assigned Objective Updated. [AI.objectivesconfirm] Priority objective recieved as follows: [AI.objectiveupdate] </span>") //Objectives Updated, standby for Emergency Procedures. BEEEEP, BEEEP
 	busystatus = 1
+	playsound(loc, 'sound/machines/chime.ogg', 25, 0)
 
 /mob/living/silicon/robot/verb/togglebusy()
 	set category = "Robot Commands"
@@ -1280,7 +1281,7 @@
 	set desc = "Toggle your busy flag off/online to indicate your status to your A.I"
 	busystatus = !busystatus
 	playsound(loc, 'sound/machines/ding.ogg', 25)
-	to_chat(usr, "<span class='notice>Flag Toggled [busystatus ? "Offline, unavailable for lowpriority tasking." : "Online, ready for assignment."]</span>")
+	to_chat(usr, "<span class='notice'>Flag Toggled [busystatus ? "Offline, unavailable for lowpriority tasking." : "Online, ready for assignment."]</span>")
 
 /mob/living/silicon/robot/verb/setobjective()
 	set category = "Robot Commands"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -339,7 +339,7 @@
 		tab_data["Master AI"] = GENERATE_STAT_TEXT("[connected_ai.name]")
 		for(var/mob/living/silicon/ai/AI) //I don't understand why this needs to be under For, but it does. 
 			tab_data["A.I Objective"] = GENERATE_STAT_TEXT("[AI.objectiveupdate]") //What are your Orders Master A.I?
-			tab_data["Busy Flag"] = GENERATE_STAT_TEXT("[busystatus ? "Utilized" : "Standingby"]")
+			tab_data["Busy Flag"] = GENERATE_STAT_TEXT("[busystatus ? "Utilized" : "Standing-by"]")
 	return tab_data
 
 /mob/living/silicon/robot/restrained(ignore_grab)
@@ -1349,14 +1349,16 @@
 	set name = "Toggle Flag"
 	set desc = "Toggle your busy flag off/online to indicate your status to your A.I"
 	busystatus = !busystatus
-	to_chat(usr, "<span class='notice>Flag Toggled [busystatus ? "Offline, unavailable for lowpriority tasking." : "Online, ready for assignment."]</span>") //This isn't reading.
+	playsound(loc, 'sound/machines/ding.ogg', 25)
+	to_chat(usr, "<span class='notice>Flag Toggled [busystatus ? "Offline, unavailable for lowpriority tasking." : "Online, ready for assignment."]</span>")
 
 /mob/living/silicon/robot/verb/setobjective()
 	set category = "Robot Commands"
 	set name = "Set Current Objective"
 	set desc = "Set your current objective, will display to your A.I"
-	var/A = 1
 	busystatus = 1
-	var/mob/living/silicon/ai/AI
-	AI.objectiveupdate = input(src, "What is your current objective, this will be displayed to your A.I.","Update Objective") //Problem, Anything after this won't read, including the to_chat
-	to_chat(src, "<span class='notice'>A.I Assigned Objective Updated. Objective set as follows: [AI.objectiveupdate] </span>")
+	switch(alert("Are you sure you want to set a custom A.I Objective? This will override your previous task.", "Confirm", "Yes", "No"))
+		if("Yes")
+			for(var/mob/living/silicon/ai/AI in GLOB.alive_mob_list)
+				AI.objectiveupdate = input(src, "What is your current objective, this will be displayed to your A.I.","Update Objective") 
+				to_chat(usr, "<span class='notice'>A.I Assigned Objective Updated. Objective set as follows: [AI.objectiveupdate] </span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -36,15 +36,6 @@
 
 	var/shown_robot_modules = 0	//Used to determine whether they have the module menu shown or not
 	var/atom/movable/screen/robot_modules_background
-/** Cyborg pathing stuff-Unfinished
-	var/datum/atom_hud/data/bot_path/path_hud = new /datum/atom_hud/data/bot_path()
-	var/data_hud_type = DATA_HUD_DIAGNOSTIC_BASIC
-	var/path_image_icon = 'icons/mob/aibots.dmi'
-	var/path_image_icon_state = "path_indicator"
-	var/path_image_color = "#2189a3"
-	var/mob/living/silicon/ai/calling_ai //Important for identifying the A.I tasking it?
-	var/list/path = list() //Pathing for Cyborg Waypoints
-**/
 
 //Cyborg Objective Updates
 	var/busystatus = 0 //OCCUPADO, PLEASE HOLD
@@ -1278,71 +1269,6 @@
 	if(repairs)
 		heal_bodypart_damage(repairs, repairs - 1)
 
-/** Commented out until I can genuinely remember how byond code works
-/mob/living/silicon/robot/proc/set_path(list/newpath)	
-	path = newpath ? newpath : list()
-	if(!path_hud)
-		return
-	var/list/path_huds_watching_me = list(GLOB.huds[DATA_HUD_DIAGNOSTIC_ADVANCED])
-	if(path_hud)
-		path_huds_watching_me += path_hud
-	for(var/V in path_huds_watching_me)
-		var/datum/atom_hud/H = V
-		H.remove_from_hud(src)
-
-	var/list/path_images = hud_list[DIAG_PATH_HUD] //1015-1056 Bot.dm, I felt inspired to copy it. 
-	QDEL_LIST(path_images)
-	if(newpath)
-		for(var/i in 1 to newpath.len)
-			var/turf/T = newpath[i]
-			if(T == loc) //don't bother putting an image if it's where we already exist.
-				continue
-			var/direction = NORTH
-			if(i > 1)
-				var/turf/prevT = path[i - 1]
-				var/image/prevI = path[prevT]
-				direction = get_dir(prevT, T)
-				if(i > 2)
-					var/turf/prevprevT = path[i - 2]
-					var/prevDir = get_dir(prevprevT, prevT)
-					var/mixDir = direction|prevDir
-					if(mixDir in GLOB.diagonals)
-						prevI.dir = mixDir
-						if(prevDir & (NORTH|SOUTH))
-							var/matrix/ntransform = matrix()
-							ntransform.Turn(90)
-							if((mixDir == NORTHWEST) || (mixDir == SOUTHEAST))
-								ntransform.Scale(-1, 1)
-							else
-								ntransform.Scale(1, -1)
-							prevI.transform = ntransform
-			var/mutable_appearance/MA = new /mutable_appearance()
-			MA.icon = path_image_icon
-			MA.icon_state = path_image_icon_state
-			MA.layer = ABOVE_OPEN_TURF_LAYER
-			MA.plane = 0
-			MA.appearance_flags = RESET_COLOR|RESET_TRANSFORM
-			MA.color = path_image_color
-			MA.dir = direction
-			var/image/I = image(loc = T)
-			I.appearance = MA
-			path[T] = I
-			path_images += I
-
-	for(var/V in path_huds_watching_me)
-		var/datum/atom_hud/H = V
-		H.add_to_hud(src)
-
-/mob/living/silicon/robot/proc/flagwaypoint(caller, turf/waypoint) //Cyborgs deserve waypoints too! Poor saps..
-	set_path(get_path_to(src, waypoint, /turf/proc/Distance_cardinal, 0, 200))
-	calling_ai = caller
-	if(path && path.len) //Ensures that a valid path is calculated!
-		to_chat(caller, "<span class='danger'>Valid Route Calculated. Plotting...</span>")
-	else
-		to_chat(caller, "<span class='danger'>Failed to calculate a valid route. Ensure destination is clear of obstructions and within range.</span>")
-		set_path(null)
-
-*/
 /mob/living/silicon/robot/proc/objectivesupdate()
 	var/mob/living/silicon/ai/AI
 	to_chat(src, "<span class='notice'>A.I Assigned Objective Updated. [AI.objectivesconfirm] Priority objective recieved as follows: [AI.objectiveupdate] </span>") //Objectives Updated, standby for Emergency Procedures. BEEEEP, BEEEP

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -36,7 +36,7 @@
 
 	var/shown_robot_modules = 0	//Used to determine whether they have the module menu shown or not
 	var/atom/movable/screen/robot_modules_background
-//Cyborg pathing stuff
+/** Cyborg pathing stuff-Unfinished
 	var/datum/atom_hud/data/bot_path/path_hud = new /datum/atom_hud/data/bot_path()
 	var/data_hud_type = DATA_HUD_DIAGNOSTIC_BASIC
 	var/path_image_icon = 'icons/mob/aibots.dmi'
@@ -44,6 +44,8 @@
 	var/path_image_color = "#2189a3"
 	var/mob/living/silicon/ai/calling_ai //Important for identifying the A.I tasking it?
 	var/list/path = list() //Pathing for Cyborg Waypoints
+**/
+
 //Cyborg Objective Updates
 	var/busystatus = 0 //OCCUPADO, PLEASE HOLD
 
@@ -1276,6 +1278,7 @@
 	if(repairs)
 		heal_bodypart_damage(repairs, repairs - 1)
 
+/** Commented out until I can genuinely remember how byond code works
 /mob/living/silicon/robot/proc/set_path(list/newpath)	
 	path = newpath ? newpath : list()
 	if(!path_hud)
@@ -1339,6 +1342,7 @@
 		to_chat(caller, "<span class='danger'>Failed to calculate a valid route. Ensure destination is clear of obstructions and within range.</span>")
 		set_path(null)
 
+*/
 /mob/living/silicon/robot/proc/objectivesupdate()
 	var/mob/living/silicon/ai/AI
 	to_chat(src, "<span class='notice'>A.I Assigned Objective Updated. [AI.objectivesconfirm] Priority objective recieved as follows: [AI.objectiveupdate] </span>") //Objectives Updated, standby for Emergency Procedures. BEEEEP, BEEEP

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1271,9 +1271,10 @@
 
 /mob/living/silicon/robot/proc/objectivesupdate()
 	var/mob/living/silicon/ai/AI
-	to_chat(src, "<span class='notice'>A.I Assigned Objective Updated. [AI.objectivesconfirm] Priority objective recieved as follows: [AI.objectiveupdate] </span>") //Objectives Updated, standby for Emergency Procedures. BEEEEP, BEEEP
 	busystatus = 1
 	playsound(loc, 'sound/machines/chime.ogg', 25, 0)
+	to_chat(usr, "<span class='notice'>A.I Assigned Objective Updated. [AI.objectivesconfirm] Priority objective recieved as follows: [AI.objectiveupdate] </span>") //Objectives Updated, standby for Emergency Procedures. BEEEEP, BEEEP
+
 
 /mob/living/silicon/robot/verb/togglebusy()
 	set category = "Robot Commands"
@@ -1287,9 +1288,9 @@
 	set category = "Robot Commands"
 	set name = "Set Current Objective"
 	set desc = "Set your current objective, will display to your A.I"
-	busystatus = 1
 	switch(alert("Are you sure you want to set a custom A.I Objective? This will override your previous task.", "Confirm", "Yes", "No"))
 		if("Yes")
 			for(var/mob/living/silicon/ai/AI in GLOB.alive_mob_list)
-				AI.objectiveupdate = input(src, "What is your current objective, this will be displayed to your A.I.","Update Objective") 
+				AI.objectiveupdate = input(src, "What is your current objective, this will be displayed to your A.I.","Update Objective")
+				busystatus = 1
 				to_chat(usr, "<span class='notice'>A.I Assigned Objective Updated. Objective set as follows: [AI.objectiveupdate] </span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds non-functional Waypoint code to cyborgs. God Damn you Bot Code.

Introduces a new A.I Verb, "Cyborg Management Panel", with a full UI detailing Linked Cyborgs, their Charge, Location, and allows the A.I to send Private messages.

Also introduces a Objective crossreference system for A.I's and Cyborgs. Cyborgs are marked as either Occupied or Unoccupied on the A.I's Management panel(also found on their own Status tabs). Cyborgs can manually switch their readiness for tasking with the "Toggle Flag" verb.

A.I's can set an objective for any linked Cyborgs from their Management Panel. Cyborgs can always find their current assigned objective in their status panel. Alternatively, Cyborgs are free to set their own objectives with the "Set Current Objective" verb.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I've heard several agreements in the past about Cyborg Management and Tasking in General, i'm hoping to resolve that but having a headache in the process with BotCode. This gives the A.I another tool for managing large crowds of Cyborgs, and allows them to keep track of their synthetics even if they've switched off their Status Tab. 

Development Status: 

- [X] A.I Task/Objective Management
- [X] A.I Cyborg Management Panel
- [x] Cyborg Task System(bugs and errors)