### PR TITLE
Nuclear Operative war edits

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,7 +1,7 @@
 #define CHALLENGE_TIME_LIMIT 4500
-#define CHALLENGE_MIN_PLAYERS 20
+#define CHALLENGE_MIN_PLAYERS 25
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
-#define CHALLENGE_TELECRYSTALS 250
+#define CHALLENGE_TELECRYSTALS 200
 
 /obj/item/nuclear_challenge
 	name = "Declaration of War (Challenge Mode)"

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,7 +1,7 @@
-#define CHALLENGE_TELECRYSTALS 280
-#define CHALLENGE_TIME_LIMIT 3000
-#define CHALLENGE_MIN_PLAYERS 50
+#define CHALLENGE_TIME_LIMIT 4500
+#define CHALLENGE_MIN_PLAYERS 20
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
+#define CHALLENGE_TELECRYSTALS 250
 
 /obj/item/nuclear_challenge
 	name = "Declaration of War (Challenge Mode)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nukeops can declare war at 25 people, have 7 1/2 minutes to do it, and have the amount of TC they gain reduced to 200 from 280.


## Why It's Good For The Game

50 people is kind of... unobtainable currently? I'm reducing the numbers of everything to try and balance it out. Also, nukeops war is just fun.

## Changelog
:cl:
add: Nukeops can declare war at 25 people, have 7 1/2 minutes to do it, and have the amount of TC they gain reduced.
/:cl: