### PR TITLE
Adds an official "request ERT" button to comms consoles.

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -289,6 +289,23 @@
 				deadchat_broadcast("<span class='deadsay'><span class='name'>[usr.real_name]</span> has messaged CentCom, \"[input]\" at <span class='name'>[get_area_name(usr, TRUE)]</span>.</span>", usr)
 				CM.lastTimeUsed = world.time
 
+		if("RequestERT")
+			if(authenticated)
+				if(!checkCCcooldown())
+					to_chat(usr, "<span class='warning'>Arrays recycling.  Please stand by.</span>")
+					return
+				if(get_dist(usr, src) > 1)
+					return
+				if(alert("Are you sure you want to request an ERT squad?","Yes","No") != "Yes")
+					return
+				var/input = stripped_input(usr, "Please any additional information or reasoning that CentCom may require. Note this does not guarantee a response.", "Please enter neccessary information.", "")
+				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
+				CentCom_announce("[usr] is requesting an ERT squad, with the reason: [input].", usr)
+				to_chat(usr, "<span class='notice'>Emergency Response Team request transmitted to Central Command.</span>")
+				usr.log_talk(input, LOG_SAY, tag="CentCom announcement")
+				deadchat_broadcast("<span class='deadsay'><span class='name'>[usr.real_name]</span> has requested an ERT squad from CentCom, with the message, \"[input]\" at <span class='name'>[get_area_name(usr, TRUE)]</span>.</span>", usr)
+				CM.lastTimeUsed = world.time
+
 		// OMG SYNDICATE ...LETTERHEAD
 		if("MessageSyndicate")
 			if((authenticated) && (obj_flags & EMAGGED))
@@ -478,6 +495,7 @@
 					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=changeseclevel'>Change Alert Level</A> \]"
 					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=emergencyaccess'>Emergency Maintenance Access</A> \]"
 					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=nukerequest'>Request Nuclear Authentication Codes</A> \]"
+					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=RequestERT'>Request Emergency Response Team</A> \]"
 					if(!(obj_flags & EMAGGED))
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=MessageCentCom'>Send Message to CentCom</A> \]"
 					else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a "Request ERT" button to comms consoles, allowing authenticated people to request admins to spawn an ERT to assist the station however needed.

Please don't abuse this

## Why It's Good For The Game
We've (admins) have used ERTs enough and we'd like the on-station authorities to ask for them more, versus admins just spawning them in.

## Changelog
:cl:
add: Comms consoles now have a "request ERT" button.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
