### PR TITLE
Slime dupes and borgs

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -329,11 +329,11 @@ ALLOW_AI_MULTICAM
 
 ## Secborg ###
 ## Uncomment to prevent the security cyborg module from being chosen
-DISABLE_SECBORG
+#DISABLE_SECBORG
 
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg module from being chosen
-DISABLE_PEACEBORG
+#DISABLE_PEACEBORG
 
 ## AWAY MISSIONS ###
 
@@ -626,7 +626,7 @@ MAX_CHICKENS 100
 MAX_SLIMES 100
 
 ## Max amount of bodies allowed to slimepeople. Has balance considerations as well as technical ones.
-MAX_SLIMEPERSON_BODIES 3
+MAX_SLIMEPERSON_BODIES 1
 
 ## Uncomment to restrict suiciding. Adds an additional confirmation dialogue, additional logging, and prevents suicide within the first 15 minutes of the round.
 RESTRICTED_SUICIDE


### PR DESCRIPTION
 Slimes and borgs, dudes.


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Scales back the number of active slime bodies a slime race can have from 3 to 1. This PR also re-enables security and peacekeeping borgs. 

## Why It's Good For The Game

Conga lines of slime people were funny at first, but present problems for players needing to assassinate these targets as well as grants the player in question WAY too much survivability. I also don't see why we shouldn't grant more options for borg and AI players.

## Changelog
:cl:
changed: MAX_SLIMEPERSON_BODIES from 3 to 1
changed: Commented in DISABLE_SECBORG+PEACEBORG to re-enable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
