### PR TITLE
Nightshift duration

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -4,8 +4,8 @@ SUBSYSTEM_DEF(nightshift)
 	flags = SS_NO_TICK_CHECK
 
 	var/nightshift_active = FALSE
-	var/nightshift_start_time = 702000		//7:30 PM, station time
-	var/nightshift_end_time = 270000		//7:30 AM, station time
+	var/nightshift_start_time = 828000		//11:00 PM, station time
+	var/nightshift_end_time = 216000		//6:00 AM, station time
 	var/nightshift_first_check = 30 SECONDS
 
 	var/high_security_mode = FALSE


### PR DESCRIPTION



<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the current shift lighting from 7:30PM-7:30AM (12 hour window) to 11:00PM-6:00AM (7 hour window).

## Why It's Good For The Game

Allows for a smaller night shift lighting window, as to keep it active while on stream times and not being too annoying for folks playing on our extended hours.

## Changelog
:cl:Did a thing, changed the numbers./:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
