### PR TITLE
Added BrigPhys vest to their locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -85,6 +85,7 @@
 	new /obj/item/clothing/gloves/color/latex/nitrile(src)
 	new /obj/item/clothing/under/rank/brig_phys(src)
 	new /obj/item/clothing/under/rank/brig_phys/skirt(src)
+	new /obj/item/clothing/suit/hazardvest/brig_phys(src)
 
 /obj/structure/closet/secure_closet/hos
 	name = "\proper head of security's locker"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Brig Physicians vest doesn't spawn in its locker, therefor people who don't roundstart as it have no possible way of obtaining it. 

## Why It's Good For The Game

Allows people to become Brig Physician who don't roundstarting as the job, to operate properly without having a deficit in gear available to them.

## Changelog
:cl:
add: Brig Physicians vest to their secure locker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
