### PR TITLE
Adjusted blueshirt gear price/supply

### DIFF
--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -15,15 +15,15 @@
 					/obj/item/flashlight/seclite = 4,
 					/obj/item/holosign_creator/security = 3,
 					/obj/item/restraints/legcuffs/bola/energy = 7,
-					/obj/item/club = 5)
+					/obj/item/club = 5,
+				    /obj/item/clothing/head/helmet/blueshirt = 2,
+				    /obj/item/clothing/suit/armor/vest/blueshirt = 2)
 	contraband = list(/obj/item/clothing/glasses/sunglasses/advanced = 2,
 					  /obj/item/storage/fancy/donut_box = 2)
 	premium = list(/obj/item/storage/belt/security/webbing = 5,
 					/obj/item/storage/backpack/duffelbag/sec/deputy = 4,
 				   /obj/item/coin/antagtoken = 1,
 				   /obj/item/grenade/barrier = 4,
-				   /obj/item/clothing/head/helmet/blueshirt = 1,
-				   /obj/item/clothing/suit/armor/vest/blueshirt = 1,
 				   /obj/item/grenade/stingbang = 1)
 	refill_canister = /obj/item/vending_refill/security
 	default_price = 100

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -16,7 +16,7 @@
 					/obj/item/holosign_creator/security = 3,
 					/obj/item/restraints/legcuffs/bola/energy = 7,
 					/obj/item/club = 5,
-					// Donkstation Change Start: PR #79
+					// Donkstation Change Start: blue security clothing is free for security
 				    /obj/item/clothing/head/helmet/blueshirt = 2,
 				    /obj/item/clothing/suit/armor/vest/blueshirt = 2)
 					// Donkstation Change End: PR #79

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -16,8 +16,10 @@
 					/obj/item/holosign_creator/security = 3,
 					/obj/item/restraints/legcuffs/bola/energy = 7,
 					/obj/item/club = 5,
+					// Donkstation Change Start: PR #79
 				    /obj/item/clothing/head/helmet/blueshirt = 2,
 				    /obj/item/clothing/suit/armor/vest/blueshirt = 2)
+					// Donkstation Change End: PR #79
 	contraband = list(/obj/item/clothing/glasses/sunglasses/advanced = 2,
 					  /obj/item/storage/fancy/donut_box = 2)
 	premium = list(/obj/item/storage/belt/security/webbing = 5,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Decreased the status of the Blueshirt armor/helmet from the SecTech vendor to be free with a security ID but priced for everyone else (aka: from premium to normal. Also increased the amount by 1, just to make it less rare for some mere cosmetical difference items.

## Why It's Good For The Game

1. Decreases the probability of the un-experienced player seeing a very expensive set of armor and assuming its "better" then their normal ones.
2. Increases the variety of security gear to have more colours then just Black/Red

## Changelog
:cl:
tweak: Decreased blueshirt helmet from 450cr > free [with a security ID]
tweak: Decreased blueshirt armor from 600cr > free [with a security ID]
tweak: Increased blueshirt armor/helmet SecTech availibity from 1 > 2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
