### PR TITLE
Ports Skyrat-tg#4322, Heretics no longer gib their sacrifice targets

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_knowledge.dm
@@ -265,7 +265,12 @@
 		if(LH.target && LH.target.stat == DEAD)
 			to_chat(carbon_user,"<span class='danger'>Your patrons accepts your offer..</span>")
 			var/mob/living/carbon/human/H = LH.target
-			H.gib()
+			//DONKSTATION CHANGE START: heretics no longer gib their targets, port of Skyrat-SS13/Skyrat-tg#4322
+			var/obj/item/bodypart/chest/chest = H.get_bodypart(BODY_ZONE_CHEST)
+			chest.dismember()
+			H.visible_message("<span class='danger'>[H.name] Is quickly surrounded by invisible claws; lacerating their chest open, spilling their organs out!</span>", \
+								"<span class='danger'>You feel claws tear your chest open; spilling your organs out onto the floor!</span>", ignored_mobs=H)
+			//DONKSTATION CHANGE END
 			LH.target = null
 			var/datum/antagonist/heretic/EC = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)
 
@@ -316,7 +321,7 @@
 	required_atoms = list(/obj/item/organ/eyes,/obj/item/stack/sheet/animalhide/human,/obj/item/storage/book/bible,/obj/item/pen)
 	result_atoms = list(/obj/item/forbidden_book/empty)
 	route = "Start"
-	
+
 //	---	CRAFTING ---
 
 /datum/eldritch_knowledge/ashen_eyes
@@ -353,7 +358,7 @@
 	cost = 1
 	required_atoms = list(/obj/structure/reagent_dispensers/watertank)
 	result_atoms = list(/obj/item/reagent_containers/glass/beaker/eldritch)
-	
+
 //	---	CURSES ---
 
 /datum/eldritch_knowledge/curse/alteration
@@ -371,7 +376,7 @@
 	var/list/extra_atoms = list()
 
 	//check variables
-	for(var/A in range(1, loc))	//this		
+	for(var/A in range(1, loc))	//this
 		var/obj/item/bodypart/selected_part = A
 		if (istype(selected_part) && selected_part.status == BODYPART_ORGANIC)
 			switch(selected_part.body_zone)
@@ -387,7 +392,7 @@
 				if(BODY_ZONE_L_ARM)
 					extra_atoms |= A
 					debuffs |= "l_arm"
-	
+
 		var/obj/item/organ/selected_organ = A
 		if (istype(selected_organ) && selected_organ.status == ORGAN_ORGANIC)
 			switch(selected_organ.slot)
@@ -413,7 +418,7 @@
 	var/mob/living/carbon/human/chosen_mortal = chosen_mob
 	if (!istype(chosen_mob))
 		return
-	
+
 	chosen_mortal.apply_status_effect(/datum/status_effect/corrosion_curse)	//the purpose of this debuff is to alert the victim they've been cursed
 	for(var/X in debuffs)
 		switch (X)
@@ -452,7 +457,7 @@
 	chosen_mortal.update_mobility()
 
 	return .
-	
+
 //	--- SPELLS ---
 
 /datum/eldritch_knowledge/spell/cleave
@@ -470,7 +475,7 @@
 	cost = 1
 	spell_to_add = /obj/effect/proc_holder/spell/targeted/touch/blood_siphon
 	next_knowledge = list(/datum/eldritch_knowledge/summon/raw_prophet,/datum/eldritch_knowledge/spell/area_conversion)
-	
+
 //	--- SUMMONS ---
 
 /datum/eldritch_knowledge/summon/ashy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes it so that Heretics no longer gib their sacrifice target, instead only spilling out their internal (chest) organs

## Why It's Good For The Game

Heretic can be hard to play as a non-murderbone antagonist because of their need to gib people to advance. This should help with that, in addition to giving more use to cybernetic organs.

## Changelog
:cl:
tweak: Heretics no longer gib their sacrifice target, instead only spilling out their internal organs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
